### PR TITLE
Asset (Media) モデルを作成した

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -1,0 +1,2 @@
+class Asset < ApplicationRecord
+end

--- a/db/migrate/20210530054154_create_assets.rb
+++ b/db/migrate/20210530054154_create_assets.rb
@@ -1,0 +1,8 @@
+class CreateAssets < ActiveRecord::Migration[6.1]
+  def change
+    create_table :assets do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210530054154_create_assets.rb
+++ b/db/migrate/20210530054154_create_assets.rb
@@ -1,6 +1,11 @@
 class CreateAssets < ActiveRecord::Migration[6.1]
   def change
     create_table :assets do |t|
+      t.bigint :id_number
+      t.string :url
+      t.string :asset_type
+
+      t.references :tweet
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_30_053438) do
+ActiveRecord::Schema.define(version: 2021_05_30_054154) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "assets", force: :cascade do |t|
+    t.bigint "id_number"
+    t.string "url"
+    t.string "asset_type"
+    t.bigint "tweet_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["tweet_id"], name: "index_assets_on_tweet_id"
+  end
 
   create_table "hashtags", force: :cascade do |t|
     t.string "text"

--- a/spec/factories/assets.rb
+++ b/spec/factories/assets.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :asset do
+    
+  end
+end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Asset, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
`Media` という命名だと、単数形・複数形で直感的でなくなるので、`Asset` とした。
