### PR TITLE
fix: 🐛 Tweetのカラムのis_retweetedという命名は混乱を招きかねないので修正した

### DIFF
--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -9,11 +9,28 @@ class Tweet < ApplicationRecord
 
   validates :id_number, uniqueness: true
 
+  # TODO: TweetStorage の方にも書く
+  def self.filter_tweeted_at(from, to)
+    where('tweeted_at > ?', from).where('tweeted_at < ?', to)
+  end
+
   def public?
     is_public
   end
 
   def source_app_name
     source
+  end
+
+  def in_reply_to_tweet
+    Tweet.find_by(id_number: in_reply_to_tweet_id_number)
+  end
+
+  def in_reply_to_user
+    User.find_by(id_number: in_reply_to_user_id_number)
+  end
+
+  def retweet?
+    is_retweet
   end
 end

--- a/db/migrate/20210530044047_create_tweets.rb
+++ b/db/migrate/20210530044047_create_tweets.rb
@@ -6,7 +6,7 @@ class CreateTweets < ActiveRecord::Migration[6.1]
       t.string 'source'
       t.bigint 'in_reply_to_tweet_id_number'
       t.bigint 'in_reply_to_user_id_number'
-      t.boolean 'is_retweeted'
+      t.boolean 'is_retweet'
       t.string 'language'
       t.boolean 'is_public'
       t.datetime 'tweeted_at'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -53,7 +53,7 @@ ActiveRecord::Schema.define(version: 2021_05_30_054844) do
     t.string "source"
     t.bigint "in_reply_to_tweet_id_number"
     t.bigint "in_reply_to_user_id_number"
-    t.boolean "is_retweeted"
+    t.boolean "is_retweet"
     t.string "language"
     t.boolean "is_public"
     t.datetime "tweeted_at"


### PR DESCRIPTION
「その Tweet が RT なのかどうか」、という意味では単純に `is_retweet` の方が分かりやすい。