### PR TITLE
運営アカの絞り込みの compact メソッドが破壊的になっていた (compact!) ので修正

### DIFF
--- a/app/lib/google_sheet_api/write_to_response_api_sheet_by_hashtag.rb
+++ b/app/lib/google_sheet_api/write_to_response_api_sheet_by_hashtag.rb
@@ -87,7 +87,7 @@ module GoogleSheetApi
         tweeted_at: beginning_at..end_at
       )
       active_record_relation = active_record_relation.not_retweet if options[:remove_rt] == true
-      active_record_relation = active_record_relation.not_by_gensosenkyo if options[:not_by_gensosenkyo] == true
+      active_record_relation = active_record_relation.not_by_gensosenkyo_families if options[:not_by_gensosenkyo_families] == true
 
       if end_search_tweet_id_number.present?
         active_record_relation = active_record_relation.where(

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -26,7 +26,7 @@ class Tweet < ApplicationRecord
     target_user_ids = [
       User.find_by(id_number: 1471724029)&.id,
       User.find_by(id_number: 1388758231825018881)&.id,
-    ].compact!
+    ].compact
 
     where.not(user_id: target_user_ids)
   end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -19,12 +19,28 @@ class Tweet < ApplicationRecord
     where(tweeted_at: from..to)
   end
 
-  def self.not_by_gensosenkyo
+  def self.not_by_gensosenkyo_families
     # gensosenkyo: 1471724029,
     # sub_gensosenkyo: 1388758231825018881
 
     target_user_ids = [
       User.find_by(id_number: 1471724029)&.id,
+      User.find_by(id_number: 1388758231825018881)&.id,
+    ].compact
+
+    where.not(user_id: target_user_ids)
+  end
+
+  def self.not_by_gensosenkyo_main
+    target_user_ids = [
+      User.find_by(id_number: 1471724029)&.id,
+    ].compact
+
+    where.not(user_id: target_user_ids)
+  end
+
+  def self.not_by_gensosenkyo_sub
+    target_user_ids = [
       User.find_by(id_number: 1388758231825018881)&.id,
     ].compact
 


### PR DESCRIPTION
- fix: 🐛 変数に代入するのに破壊的メソッドを使っていたので修正
- feat: 🎸 サブアカについては無視しないことが普通なのでメソッドを分離、修正した
