### PR TITLE
v4.0.1

### DIFF
--- a/app/lib/suikoden_database/pickup_character_names.rb
+++ b/app/lib/suikoden_database/pickup_character_names.rb
@@ -26,8 +26,14 @@ module SuikodenDatabase
         false
       end
 
+      # check_words の中身を連続で見ていった際に、これらの語の場合はキャラ名サーチをしない
       def skip_words
         [
+          '一',
+          'な',
+          'る',
+          'なる',
+          '王',
           '異',
           '世',
           '界',

--- a/app/models/analyze_syntax.rb
+++ b/app/models/analyze_syntax.rb
@@ -58,7 +58,7 @@ class AnalyzeSyntax < ApplicationRecord
       words_with_noun_and_x_tags.map { |word| remove_all_three_point_readers_from_word(word) } +
       words_with_noun_and_x_tags.map { |word| convert_hankaku_katakana_to_zenkaku_katakana(word) } +
       words_with_noun_and_x_tags.map { |word| convert_zenkaku_numbers_to_hankaku_numbers(word) }
-    ).uniq
+    ).uniq.reject(&:empty?)
   end
   # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
 


### PR DESCRIPTION
- fix: 🐛 ドロップダウンキャラ名検索において LIKE "%%" になって全キャラ対象になる不具合を修正した (#115)