### PR TITLE
fix: 🐛 ツイートの並び順の一意性が保たれていなかった不具合を修正した

### DIFF
--- a/app/lib/google_sheet_api/write_to_response_api_sheet_by_hashtag.rb
+++ b/app/lib/google_sheet_api/write_to_response_api_sheet_by_hashtag.rb
@@ -101,9 +101,14 @@ module GoogleSheetApi
         )
       end
 
+      # tweetd_at のみの ORDER_BY では秒単位で一致する可能性があるので、id_number も用いる（id_number だけでもいい）
       active_record_relation.where(
         id_number: beginning_search_tweet_id_number..
-      ).order(tweeted_at: :asc)
+      ).order(
+        tweeted_at: :asc
+      ).order(
+        id_number: :asc
+      )
     end
     # rubocop:enable Style/ConditionalAssignment
 

--- a/app/lib/google_sheet_api/write_to_tallied_sheet.rb
+++ b/app/lib/google_sheet_api/write_to_tallied_sheet.rb
@@ -74,6 +74,7 @@ module GoogleSheetApi
         .valid_term_votes
         .to_gensosenkyo_main
         .order(messaged_at: :asc)
+        .order(id_number: :asc)
     end
 
     def character_names_for_dropdown(tweet_or_dm)
@@ -90,6 +91,7 @@ module GoogleSheetApi
         .contains_hashtag('幻水総選挙2021')
         .not_by_gensosenkyo_main
         .order(tweeted_at: :asc)
+        .order(id_number: :asc)
     end
 
     def odai_shosetsu_tweets
@@ -99,6 +101,7 @@ module GoogleSheetApi
         .contains_hashtag('幻水総選挙お題小説')
         .where(tweeted_at: ..Time.zone.parse('2021-06-07 02:20:00'))
         .order(tweeted_at: :asc)
+        .order(id_number: :asc)
     end
 
     def oshi_serifu_tweets
@@ -108,6 +111,7 @@ module GoogleSheetApi
         .contains_hashtag('幻水総選挙推し台詞')
         .where(tweeted_at: ..Time.zone.parse('2021-06-10 23:59:59'))
         .order(tweeted_at: :asc)
+        .order(id_number: :asc)
     end
 
     # rubocop:disable Style/RedundantInterpolation

--- a/app/lib/twitter_rest_api/check_public_tweets.rb
+++ b/app/lib/twitter_rest_api/check_public_tweets.rb
@@ -38,6 +38,7 @@ module TwitterRestApi
       not_public_tweet_id_numbers = []
 
       # データベースに保存してある id_number のツイートを一挙取得して、戻り値に存在するかどうかで public かそうでないかを判断する
+      # TODO: 並び順の一意性の確保のため、order(id_number: :asc)
       Tweet.order(tweeted_at: :asc).pluck(:id_number).each_slice(100) do |sliced_all_id_numbers|
         sliced_id_numbers_tweets_id_numbers = @client.statuses(sliced_all_id_numbers).map(&:id)
         not_public_tweet_id_numbers_in_this_sliced_id_numbers = sliced_all_id_numbers - sliced_id_numbers_tweets_id_numbers

--- a/app/lib/twitter_rest_api/update_user_records.rb
+++ b/app/lib/twitter_rest_api/update_user_records.rb
@@ -77,6 +77,7 @@ module TwitterRestApi
       not_public_user_objects = []
       public_user_objects = []
 
+      # TODO: 並び順の一意性の確保のため、order(id_number: :asc)
       User.order(created_at: :asc).pluck(:id_number).each_slice(100) do |sliced_all_id_numbers|
         sliced_id_numbers_users = @client.users(sliced_all_id_numbers)
 

--- a/app/models/tweet_from_tweet_storage.rb
+++ b/app/models/tweet_from_tweet_storage.rb
@@ -16,6 +16,7 @@ class TweetFromTweetStorage < ApplicationRecord
   scope :order_by_id_number_asc, -> { order(id_number: :asc) }
 
   # TODO: Refactoring
+  # TODO: 並び順の一意性の確保のため、order(id_number: :asc)
   # Pick up the latest id_number record
   scope :remove_duplicated, lambda {
     tweet_id_numbers = pluck(:id_number)


### PR DESCRIPTION
tweetd_at ではなく、id_number を（も）用いる
