### PR TITLE
feat: 🎸 Ruby 3.4 で Obsolete になる "csv" gem を明示的に追加した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'rails'
 
 gem 'bootsnap', require: false
 gem 'bugsnag'
+gem 'csv'
 gem 'dotenv-rails'
 gem 'google-apis-sheets_v4'
 gem 'google-cloud-language'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.1)
     crass (1.0.6)
+    csv (3.3.4)
     date (3.4.1)
     declarative (0.0.20)
     diff-lcs (1.5.1)
@@ -414,6 +415,7 @@ DEPENDENCIES
   bootsnap
   bugsnag
   byebug
+  csv
   dotenv-rails
   factory_bot_rails
   google-apis-sheets_v4


### PR DESCRIPTION
This pull request adds a new dependency to the project by including the `csv` gem in the `Gemfile`.

Dependency changes:

* [`Gemfile`](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR10): Added the `csv` gem to enable CSV file handling within the application.